### PR TITLE
Fix: Enhance click action with page load state wait

### DIFF
--- a/.changeset/chatty-memes-nail.md
+++ b/.changeset/chatty-memes-nail.md
@@ -1,0 +1,5 @@
+---
+"Factifai": patch
+---
+
+Add a wait for the 'domcontentloaded' state after performing a click action to ensure the page is fully loaded.

--- a/backend/src/services/implementations/puppeteer/PuppeteerService.ts
+++ b/backend/src/services/implementations/puppeteer/PuppeteerService.ts
@@ -113,7 +113,11 @@ export class PuppeteerService extends BaseStreamingService {
             message: "Browser closed successfully" 
           };
         case "click":
-          return await PuppeteerActions.click(PuppeteerService.page, action);
+          const response = await PuppeteerActions.click(PuppeteerService.page, action);
+          await PuppeteerService.page.waitForLoadState("domcontentloaded", {
+            timeout: 20_000,
+          });
+          return response;
         case "type":
           return await PuppeteerActions.type(PuppeteerService.page, action);
         case "scroll_up":
@@ -317,7 +321,7 @@ export class PuppeteerService extends BaseStreamingService {
           "Browser is not launched. Please launch the browser first."
         );
       }
-      
+
       // Get context safely
       const contexts = PuppeteerService.browser.contexts();
       if (!contexts || contexts.length === 0) {
@@ -337,8 +341,7 @@ export class PuppeteerService extends BaseStreamingService {
       // Take screenshot with error handling
       try {
         const buffer = await page.screenshot({ type: "png" });
-        const base64Image = buffer.toString("base64");
-        return base64Image;
+        return buffer.toString("base64");
       } catch (screenshotError) {
         this.emitConsoleLog("error", `Screenshot error: ${screenshotError}`);
         throw screenshotError;


### PR DESCRIPTION

### Description

Add a wait for the 'domcontentloaded' state after performing a click action to ensure the page is fully loaded. 
This improves reliability when handling actions that trigger page navigation or dynamic content loading.


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/factif-ai/blob/main/CONTRIBUTING.md)

